### PR TITLE
Add cf context to metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -38,6 +38,15 @@ interface RequestMetrics {
     streamComplete?: boolean; // Whether stream completed successfully
     [key: string]: any;     // Additional provider-specific metadata
   };
+  location?: {
+    city: string;
+    country: string;
+    continent: string;
+    latitude: string;
+    longitude: string;
+    timezone: string;
+    region: string;
+  };
 }
 ```
 
@@ -64,6 +73,15 @@ interface RequestMetrics {
     "totalChunks": 15,
     "streamComplete": true,
     "systemFingerprint": "fp_1234"
+  },
+  "location": {
+    "city": "San Francisco",
+    "country": "US",
+    "continent": "NA",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "timezone": "America/Los_Angeles",
+    "region": "California"
   },
   "model": "gpt-4",
   "status": 200,
@@ -107,6 +125,15 @@ interface RequestMetrics {
     "streamComplete": true,
     "messageId": "msg_123"
   },
+  "location": {
+    "city": "San Francisco",
+    "country": "US",
+    "continent": "NA",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "timezone": "America/Los_Angeles",
+    "region": "California"
+  },
   "model": "claude-3-sonnet-20240229-v1:0",
   "status": 200,
   "tokens": {
@@ -139,6 +166,15 @@ interface RequestMetrics {
     "streamComplete": true,
     "seed": 9180670685818186000
   },
+  "location": {
+    "city": "San Francisco",
+    "country": "US",
+    "continent": "NA",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "timezone": "America/Los_Angeles",
+    "region": "California"
+  },
   "model": "meta-llama/Llama-2-7b-chat-hf",
   "status": 200,
   "tokens": {
@@ -169,6 +205,15 @@ interface RequestMetrics {
     "estimated": false,
     "totalChunks": 76,
     "streamComplete": true
+  },
+  "location": {
+    "city": "San Francisco",
+    "country": "US",
+    "continent": "NA",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "timezone": "America/Los_Angeles",
+    "region": "California"
   },
   "model": "llama-3.1-8b-instant",
   "status": 200,
@@ -205,6 +250,15 @@ interface RequestMetrics {
     "estimated": false,
     "totalChunks": 24,
     "streamComplete": true
+  },
+  "location": {
+    "city": "San Francisco",
+    "country": "US",
+    "continent": "NA",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "timezone": "America/Los_Angeles",
+    "region": "California"
   },
   "model": "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
   "status": 200,

--- a/src/handlers/chat.ts
+++ b/src/handlers/chat.ts
@@ -46,11 +46,16 @@ export const handleChatCompletion = async (c: Context<{ Variables: Variables; Bi
     // Get provider instance
     providerInstance = ProviderFactory.getProvider(provider, config);
     console.debug('[ChatCompletion] Initialized provider');
-
     // Make the request to the provider
     console.debug('[ChatCompletion] Processing request');
     const response = await providerInstance.chatCompletion(request);
     console.debug('[ChatCompletion] Request processed');
+
+    // Set Cloudflare context data if available
+    const metricsCollector = providerInstance?.getMetricsCollector();
+    if (metricsCollector) {
+      metricsCollector.setCloudflareContext(c.req.raw);
+    }
 
     // Transform response through hooks
     const transformedResponse = await hooksManager.transformResponse(response, c);

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -44,6 +44,45 @@ export class MetricsCollector {
     this.config = config;
   }
 
+  setCloudflareContext(request: Request): void {
+    const cfData = (request as any).cf;
+    if (cfData) {
+      this.setLocation({
+        city: cfData.city as string | undefined,
+        country: cfData.country as string | undefined,
+        continent: cfData.continent as string | undefined,
+        latitude: cfData.latitude as string | undefined,
+        longitude: cfData.longitude as string | undefined,
+        timezone: cfData.timezone as string | undefined,
+        region: cfData.region as string | undefined
+      });
+      console.debug('[Metrics] Location data set from Cloudflare context');
+    }
+  }
+
+  setLocation(cf?: { 
+    city?: string;
+    country?: string;
+    continent?: string;
+    latitude?: string;
+    longitude?: string;
+    timezone?: string;
+    region?: string;
+  }) {
+    if (cf) {
+      console.debug('[Metrics] Setting Cloudflare location data:', cf);
+      this.metrics.location = {
+        city: cf.city || 'unknown',
+        country: cf.country || 'unknown',
+        continent: cf.continent || 'unknown',
+        latitude: cf.latitude || '0',
+        longitude: cf.longitude || '0',
+        timezone: cf.timezone || 'unknown',
+        region: cf.region || 'unknown'
+      };
+    }
+  }
+
   getStartTime(): number {
     return this.metrics.performance.startTime;
   }

--- a/src/metrics/exporters/elasticsearch.ts
+++ b/src/metrics/exporters/elasticsearch.ts
@@ -80,7 +80,16 @@ export class ElasticsearchExporter extends BaseExporter {
         inputCost: 0,
         outputCost: 0,
         totalCost: 0
-      }
+      },
+      location: metrics.location ? {
+        city: metrics.location.city,
+        country: metrics.location.country,
+        continent: metrics.location.continent,
+        latitude: metrics.location.latitude,
+        longitude: metrics.location.longitude,
+        timezone: metrics.location.timezone,
+        region: metrics.location.region
+      } : undefined
     };
 
     const url = `${this.url}/${this.index}/_doc/${metrics.requestId}?pretty`;

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,5 +1,6 @@
 import { BaseProvider } from './base';
 import { ChatCompletionRequest } from '../types';
+import { ANTHROPIC_COSTS } from '../metrics/costs/anthropic';
 
 interface AnthropicResponse {
   content: Array<{ text: string }>;
@@ -178,6 +179,15 @@ export class AnthropicProvider extends BaseProvider {
     try {
       this.validateConfig();
       const requestBody = await this.transformRequest(request);
+      
+      // Set token costs based on model
+      const modelName = request.model.toLowerCase().replace(/-\d{8}$/, ''); // Remove date suffix
+      const costs = ANTHROPIC_COSTS[modelName];
+      if (costs) {
+        this.config.inputTokenCost = costs.inputTokenCost;
+        this.config.outputTokenCost = costs.outputTokenCost;
+      }
+      
       const metrics = this.initializeMetrics(request);
 
       const response = await fetch(this.ANTHROPIC_API_URL, {
@@ -208,14 +218,14 @@ export class AnthropicProvider extends BaseProvider {
   extractMetrics(data: any) {
     if (!data) return null;
 
-    // Handle message_start event
+    // Handle streaming message_start event
     if (data.type === 'message_start') {
       return {
-        tokens: data.message.usage ? {
-          inputTokens: data.message.usage.input_tokens,
-          outputTokens: 0, // Will be updated in subsequent chunks
-          totalTokens: data.message.usage.input_tokens
-        } : undefined,
+        tokens: {
+          inputTokens: data.message.usage?.input_tokens || 0,
+          outputTokens: 0,
+          totalTokens: data.message.usage?.input_tokens || 0
+        },
         metadata: {
           messageId: data.message.id,
           model: data.message.model
@@ -223,29 +233,31 @@ export class AnthropicProvider extends BaseProvider {
       };
     }
 
-    // Handle message_delta event
-    if (data.type === 'message_delta') {
+    // Handle streaming message_delta event with usage info
+    if (data.type === 'message_delta' && data.usage) {
       return {
-        tokens: data.usage ? {
-          outputTokens: data.usage.output_tokens
-        } : undefined,
+        tokens: {
+          outputTokens: data.usage.output_tokens || 0,
+          totalTokens: (data.usage.input_tokens || 0) + (data.usage.output_tokens || 0)
+        },
         metadata: {
           stopReason: data.delta.stop_reason
         }
       };
     }
 
-    // Handle regular response
-    if (data.id && data.usage) {
+    // Handle non-streaming response
+    if (data.usage) {
       return {
         tokens: {
-          inputTokens: data.usage.prompt_tokens,
-          outputTokens: data.usage.completion_tokens,
-          totalTokens: data.usage.total_tokens
+          inputTokens: data.usage.input_tokens || 0,
+          outputTokens: data.usage.output_tokens || 0,
+          totalTokens: (data.usage.input_tokens || 0) + (data.usage.output_tokens || 0)
         },
         metadata: {
           messageId: data.id,
-          model: data.model
+          model: data.model,
+          stopReason: data.stop_reason
         }
       };
     }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -9,6 +9,7 @@ export interface AIProvider {
   transformResponse(response: any, request: ChatCompletionRequest): Promise<any>;
   extractMetrics?(response: any): { tokens?: any, performance?: any, metadata?: any } | null;
   getMetricsCollector(): MetricsCollector | undefined;
+  setLocation(location: any): void;
 }
 
 export abstract class BaseProvider implements AIProvider {
@@ -208,5 +209,11 @@ export abstract class BaseProvider implements AIProvider {
 
   getMetricsCollector(): MetricsCollector | undefined {
     return this.metricsCollector;
+  }
+
+  setLocation(location: any): void {
+    if (this.metricsCollector) {
+      this.metricsCollector.setLocation(location);
+    }
   }
 } 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,4 +167,13 @@ export type RequestMetrics = {
     streamComplete?: boolean;
     [key: string]: any;
   };
+  location?: {
+    city: string;
+    country: string;
+    continent: string;
+    latitude: string;
+    longitude: string;
+    timezone: string;
+    region: string;
+  };
 }; 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new optional `location` property to the metrics documentation, enhancing geographical data collection for requests.
	- Introduced methods for setting Cloudflare context and location in the metrics collector.
	- Updated metrics document structure to include `location` in the Elasticsearch exporter.
	- Enhanced the `AnthropicProvider` class to better handle token costs and streaming responses.

- **Bug Fixes**
	- Enhanced error handling and logging in the metrics collection and export processes.

- **Documentation**
	- Updated example metrics for various providers to include the new `location` object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->